### PR TITLE
fix: scheme handling in connection url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,9 +2091,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2103,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2773,6 +2773,7 @@ dependencies = [
  "convert_case",
  "itertools 0.11.0",
  "nom",
+ "regex",
  "serde",
  "surrealdb",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ clap = { version = "4.4.4", features = ["derive"] }
 convert_case = "0.6.0"
 itertools = "0.11.0"
 nom = "7.1.3"
+regex = "1.9.6"
 serde = "1.0.188"
 surrealdb = "1.0.0"
 tokio = "1.32.0"


### PR DESCRIPTION
This is a simplistic approach, where if a scheme is found (using regex) in the connection_url it is removed before passing it to surrealdb.